### PR TITLE
ppFREQ node and cold junction from ppTHERMO node

### DIFF
--- a/freq.html
+++ b/freq.html
@@ -1,0 +1,31 @@
+<script type="text/javascript">
+    RED.nodes.registerType('ppFREQ', {
+        category: 'Pi_Plates',
+        color: '#a6bbcf',
+        defaults: {
+            config_plate: { value: '', type: "pi_plate"},
+            name: { value: ''}
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: 'file.png',
+        label: function () {
+            return (this.name || 'freq');
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="ppFREQ">
+    <div class="form-row">
+        <label for="node-input-config_plate"><i class="icon-tag"></i> Plate</label>
+        <input type="text" id="node-input-config_plate">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="ppFREQ">
+    <p>Measures the frequency of any ground referenced signal with a amplitude in the range 3.3 to 5 volts as an integer value.</p>
+</script>

--- a/freq.js
+++ b/freq.js
@@ -1,0 +1,22 @@
+module.exports = function (RED) {
+    function FREQNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+        node.plate = RED.nodes.getNode(config.config_plate).plate;
+        node.input = parseInt(config.input, 10);
+        node.state = 0;
+        node.on('input', function (msg) {
+            const obj = {cmd: "getFREQ", args: {}};
+            node.plate.send(obj, (reply) => {
+                node.value = reply.value
+                node.status({text: node.value});
+                node.send({payload: node.value});
+            });
+        });
+
+        this.on('close', function () {
+            // cleanup goes here
+        });
+    }
+    RED.nodes.registerType("ppFREQ", FREQNode);
+}

--- a/led.html
+++ b/led.html
@@ -1,0 +1,37 @@
+<script type="text/javascript">
+    RED.nodes.registerType('ppLED', {
+        category: 'Pi_Plates',
+        color: '#a6bbcf',
+        defaults: {
+            config_plate: { value: '', type: "pi_plate"},
+            name: { value: ''},
+            output: { value: "0", required: true}
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: 'file.png',
+        label: function () {
+            return (this.name || 'led');
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="ppLED">
+    <div class="form-row">
+        <label for="node-input-config_plate"><i class="icon-tag"></i> Plate</label>
+        <input type="text" id="node-input-config_plate">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="ppLED">
+    <p>Control an LED on a DAQCplate, DAQC2plate, RELAYplate or THERMOplate. The ppLED
+    node accepts a string input. For all plate types, 'off' will turn the LED off. When
+    used with a RELAYplate or THERMOplate, any other value will turn the LED on. The
+    DAQCplate accepts 'red', 'green' or 'yellow' to turn on the red, green or both LEDs
+    respectively. The DAQC2plate accepts 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan'
+    and 'white'.</p>
+</script>

--- a/led.js
+++ b/led.js
@@ -1,0 +1,30 @@
+module.exports = function (RED) {
+    function LEDNode(config) {
+        RED.nodes.createNode(this, config);
+        this.plate = RED.nodes.getNode(config.config_plate).plate;
+        var node = this;
+
+        node.on('input', function (msg) {
+            const obj = {
+                cmd: 'setLED',
+                args: { color: msg.payload }
+            };
+
+            const pt = node.plate.plate_type;
+            if (pt == 'THERMO' || pt == 'RELAY') {
+                obj['cmd'] = (msg.payload == 'off' ? "clrLED" : "setLED");
+            }
+
+            node.plate.send(obj, (reply) => {
+                node.state = reply.state
+                node.status({ text: node.state });
+                node.send({ payload: node.state });
+            });
+        });
+
+        this.on('close', function () {
+            // cleanup goes here
+        });
+    }
+    RED.nodes.registerType("ppLED", LEDNode);
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "ppDIN": "din.js",
       "ppDOUT": "dout.js",
       "ppFREQ": "freq.js",
+      "ppLED": "led.js",
       "ppTEMP": "temp.js",
       "ppTHERMO": "thermo.js"
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "ppDAC": "dac.js",
       "ppDIN": "din.js",
       "ppDOUT": "dout.js",
+      "ppFREQ": "freq.js",
       "ppTEMP": "temp.js",
       "ppTHERMO": "thermo.js"
     }

--- a/thermo.html
+++ b/thermo.html
@@ -1,0 +1,59 @@
+<script type="text/javascript">
+    RED.nodes.registerType('ppTHERMO', {
+        category: 'Pi_Plates',
+        color: '#a6bbcf',
+        defaults: {
+            config_plate: { value: '', type: "pi_plate"},
+            name: { value: ''},
+            channel: { value: "1", required: true}
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: 'file.png',
+        label: function () {
+            return (this.name || 'temp');
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="ppTHERMO">
+    <div class="form-row">
+        <label for="node-input-config_plate"><i class="icon-tag"></i> Plate</label>
+        <input type="text" id="node-input-config_plate">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+<!--
+    <div class="form-row">
+        <label for="node-input-scale"><i class="icon-tag"></i> Temperature Scale</label>
+        <select id="node-input-scale">
+            <option value="Celcius">Celsius</option>
+            <option value="Fahrenheit">Fahrenheit</option>
+            <option value="Kelvin">Kelvin</option>
+        </select>
+    </div>
+-->
+    <div class="form-row">
+        <label for="node-input-channel"><i class="icon-tag"></i> Input #</label>
+        <select id="node-input-channel">
+            <option value="1">TC1</option>
+            <option value="2">TC2</option>
+            <option value="3">TC3</option>
+            <option value="4">TC4</option>
+            <option value="5">TC5</option>
+            <option value="6">TC6</option>
+            <option value="7">TC7</option>
+            <option value="8">TC8</option>
+            <option value="9">DS9</option>
+            <option value="10">DS10</option>
+            <option value="11">DS11</option>
+            <option value="12">DS12</option>
+        </select>
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="ppTHERMO">
+    <p>Temperature Input from THERMOplate board.  Inputs 1-8 are K-type thermocouple, 9-12 are DS18B20 1-wire devices.  Returned values are in degrees Celcius.</p>
+</script>

--- a/thermo.html
+++ b/thermo.html
@@ -50,10 +50,11 @@
             <option value="10">DS10</option>
             <option value="11">DS11</option>
             <option value="12">DS12</option>
+            <option value="0">COLD</option>
         </select>
     </div>
 </script>
 
 <script type="text/x-red" data-help-name="ppTHERMO">
-    <p>Temperature Input from THERMOplate board.  Inputs 1-8 are K-type thermocouple, 9-12 are DS18B20 1-wire devices.  Returned values are in degrees Celcius.</p>
+    <p>Temperature Input from THERMOplate board.  Inputs 1-8 are K-type thermocouple, 9-12 are DS18B20 1-wire devices, COLD is cold junction temperature of board.  Returned values are in degrees Celcius.</p>
 </script>

--- a/thermo.js
+++ b/thermo.js
@@ -1,0 +1,22 @@
+module.exports = function (RED) {
+    function THERMONode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+        node.plate = RED.nodes.getNode(config.config_plate).plate;
+        node.channel = parseInt(config.channel, 10);
+        node.temperature = 0;
+        node.on('input', function (msg) {
+            const obj = {cmd: "getTEMP", args: {channel: node.channel}};
+            node.plate.send(obj, (reply) => {
+                node.temperature = reply.value;
+                node.status({text: node.temperature});
+                node.send({payload: node.temperature});
+            });
+        });
+
+        this.on('close', function () {
+            // cleanup goes here
+        });
+    }
+    RED.nodes.registerType("ppTHERMO", THERMONode);
+}

--- a/thermo.js
+++ b/thermo.js
@@ -6,7 +6,8 @@ module.exports = function (RED) {
         node.channel = parseInt(config.channel, 10);
         node.temperature = 0;
         node.on('input', function (msg) {
-            const obj = {cmd: "getTEMP", args: {channel: node.channel}};
+            const cmd = node.channel==0 ? 'getCOLD' : 'getTEMP';
+            const obj = {cmd: cmd, args: {channel: node.channel}};
             node.plate.send(obj, (reply) => {
                 node.temperature = reply.value;
                 node.status({text: node.temperature});


### PR DESCRIPTION
It appears the thermo.js/html were published to npm, but not added to the git repository. The first commit in this request adds these to git.

The second commit adds support for getting the cold junction temperature from a ppTHERMO node. It treats this as channel zero in the configuration and changes the command sent from getTEMP to getCOLD if channel is zero, avoiding the need for a separate node to get this temperature.

The third commit adds a new ppFREQ node to get the frequency counter from a DAQC2plate via getFREQ.

This pull request is depends on getCOLD and getFREQ commands being added to node-pi-plates:
https://github.com/mharsch/node-pi-plates/pull/2